### PR TITLE
Fix black background of code blocks on some themes

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -13,5 +13,6 @@
 }
 
 .api-docs-doc code {
+  background-color: #fff;
   text-shadow: none;
 }


### PR DESCRIPTION
Quick fix for #5 It just adds white background to the code blocks as well as it is specified in the theme as dark and it overrides the inherited background-color from api-docs-doc parent. Probably a better fix is to use shadow DOM, which should cause Atom theme to not interfere with the documentation view, but I didn't try to see whether this will work.