### PR TITLE
Change default hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # API Documentation
 A beautiful, lightweight, offline documentation browser for Atom. Place
-your cursor on the phrase you want to search for and press `ctrl+d`
+your cursor on the phrase you want to search for and press `ctrl+alt+d`
 to search.
 
 ![api-docs demo](http://i.imgur.com/mQ0TFWr.gif)

--- a/keymaps/atom-devdocs.cson
+++ b/keymaps/atom-devdocs.cson
@@ -1,2 +1,2 @@
 'atom-text-editor':
-  'ctrl-d': 'api-docs:search-under-cursor'
+  'ctrl-alt-d': 'api-docs:search-under-cursor'


### PR DESCRIPTION
Ctrl-D is an important default hotkey in Atom.io (multi-cursors selection).

Don't try to override it, use e.g. Ctrl-Alt-D instead.