### PR TITLE
Enable keyboard commands on doc view pane

### DIFF
--- a/src/doc_view.js
+++ b/src/doc_view.js
@@ -17,7 +17,7 @@ class DocView extends ScrollView {
 
   static content() {
     // Magic required to enable scrolling and keyboard shortcuts for scrolling.
-    return this.div({class: 'api-docs-doc', tabindex: -1});
+    return this.div({class: 'api-docs-doc native-key-bindings', tabindex: -1});
   }
 
   constructor(library, url) {


### PR DESCRIPTION
Inspired by https://github.com/rgbkrk/atom-script/pull/79, added `native-key-binding` class to enable keyboard commands (eg. copying of text) from the Document View pane.

Doesn't include keyboard scrolling with cursor keys though :(